### PR TITLE
Replace 99designs/ergo with 99designs/ergo-http

### DIFF
--- a/classes/Relax/Client/Resource.php
+++ b/classes/Relax/Client/Resource.php
@@ -164,9 +164,6 @@ class Relax_Client_Resource
 
         $rel = $this->_node->relationship($method);
 
-        //Ergo::loggerFor($this)->info("dispatching $method(%s) to static relation %s",
-        //	(isset($params[0]) ? $params[0] : 'none'), $rel->type);
-
         // dispatch static relationships
         if ($rel->type == Relax_Client_Node::REL_ONE) {
             return $rel->node->resource($this->url(),$method);

--- a/classes/Relax/Openssl/AuthHmac.php
+++ b/classes/Relax/Openssl/AuthHmac.php
@@ -25,7 +25,7 @@ class Relax_Openssl_AuthHmac implements \Ergo\Http\ClientFilter
     {
         $this->_keys = $keys;
         $this->_access_id = $access_id;
-        $this->_time_func = $time_func ?: function() { return Ergo::time(); };
+        $this->_time_func = $time_func ?: function() { return date("U"); };
     }
 
     // ----------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,12 @@
 	"name": "99designs/relax",
 	"description": "A library for consuming simple REST services in PHP5.",
 	"license": "MIT",
+	"repositories": [
+		{ "type": "vcs", "url": "https://github.com/99designs/ergo-http" }
+	],
 	"require": {
 		"php": ">=5.3",
-		"99designs/ergo": "2.*"
+		"99designs/ergo-http": "1.*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.*",

--- a/tests/Relax/Client/AuthHmacTest.php
+++ b/tests/Relax/Client/AuthHmacTest.php
@@ -8,6 +8,7 @@ class Relax_Client_AuthHmacTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         // a known-good date and header for this request signed with "the_secret"
+        date_default_timezone_set('UTC');
         $this->timeFunc = function() {
             return strtotime("Tue, 22 Feb 2011 00:00:00 GMT");
         };


### PR DESCRIPTION
Replace `99designs/ergo` with `99designs/ergo-http`, as this library only the http framework. Future versions of `99designs/ergo` will have `99designs/ergo-http` as a dependecy.
