### PR TITLE
Avoid mentioning Ergo by name; cross v1/v2 compatibility.

### DIFF
--- a/classes/Relax/Openssl/AuthHmac.php
+++ b/classes/Relax/Openssl/AuthHmac.php
@@ -4,10 +4,12 @@
  * Signs and verifies HTTP requests using HMAC.
  * Based on (and compatible with) the Ruby AuthHMAC library.
  *
+ * Implicitly implements \Ergo\Http\ClientFilter and Ergo_Http_ClientFilter.
+ *
  * @see http://auth-hmac.rubyforge.org/
  * @author Paul Annesley
  */
-class Relax_Openssl_AuthHmac implements \Ergo\Http\ClientFilter
+class Relax_Openssl_AuthHmac
 {
     const HEADER_NAME = 'Authorization';
     const SERVICE_ID = 'AuthHMAC';
@@ -44,10 +46,15 @@ class Relax_Openssl_AuthHmac implements \Ergo\Http\ClientFilter
 
         $signature = $this->_signature_for_request($request, $secret);
 
-        $request->getHeaders()->add(new \Ergo\Http\HeaderField(
-            self::HEADER_NAME,
-            sprintf('%s %s:%s', self::SERVICE_ID, $this->_access_id, $signature)
-        ));
+        $request->getHeaders()->add(
+            sprintf(
+                '%s: %s %s:%s',
+                self::HEADER_NAME,
+                self::SERVICE_ID,
+                $this->_access_id,
+                $signature
+            )
+        );
 
         return $request;
     }

--- a/classes/Relax/Openssl/Signer.php
+++ b/classes/Relax/Openssl/Signer.php
@@ -3,8 +3,10 @@
 /**
  * Signs a request's components using a public key. Throws signing exceptions
  * for requests that aren't valid.
+ *
+ * Implicitly implements \Ergo\Http\ClientFilter and Ergo_Http_ClientFilter.
  */
-class Relax_Openssl_Signer implements \Ergo\Http\ClientFilter
+class Relax_Openssl_Signer
 {
     const FUTURE_SANITY_THRESHOLD=5000;
 


### PR DESCRIPTION
Ergo was PHP namespaced between its v1 and v2. Avoid mentioning it by name, so that Relax can work with either version.

Depends on these Ergo PRs which remove type hints (type requirements, really):

* https://github.com/99designs/ergo/pull/22 (ergo v1)
* https://github.com/99designs/ergo/pull/23 (ergo v2)